### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/fastcampus/newboardproject/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/newboardproject/repository/ArticleCommentRepository.java
@@ -2,7 +2,9 @@ package com.fastcampus.newboardproject.repository;
 
 import com.fastcampus.newboardproject.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 
 }

--- a/src/main/java/com/fastcampus/newboardproject/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/newboardproject/repository/ArticleRepository.java
@@ -2,7 +2,9 @@ package com.fastcampus.newboardproject.repository;
 
 import com.fastcampus.newboardproject.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,7 @@ spring:
   sql:
     init:
       mode: always
+  data:
+    rest:
+      base-path: /api
+      detection-strategy: annotated

--- a/src/test/java/com/fastcampus/newboardproject/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/newboardproject/controller/DataRestTest.java
@@ -1,0 +1,92 @@
+package com.fastcampus.newboardproject.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("Data REST - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void given_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles"))   // 해당 링크 가져옴
+            .andExpect(status().isOk())  // status가  OK인지 검사
+            .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        //  내용 검사는 hal+JSON이므로 MediaType.APPLICATION_JSON이 아니라 직접 입력해줌
+
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void given_whenRequestingArticle_thenReturnsArticleJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles/1"))   // 해당 링크 가져옴
+            .andExpect(status().isOk())  // status가  OK인지 검사
+            .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        //  내용 검사는 hal+JSON이므로 MediaType.APPLICATION_JSON이 아니라 직접 입력해줌
+
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    void given_whenRequestingArticleCommentsFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles/1/articleComments"))   // 해당 링크 가져옴
+            .andExpect(status().isOk())  // status가  OK인지 검사
+            .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        //  내용 검사는 hal+JSON이므로 MediaType.APPLICATION_JSON이 아니라 직접 입력해줌
+
+    }
+
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    void given_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articleComments"))   // 해당 링크 가져옴
+            .andExpect(status().isOk())  // status가  OK인지 검사
+            .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        //  내용 검사는 hal+JSON이므로 MediaType.APPLICATION_JSON이 아니라 직접 입력해줌
+
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    void given_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articleComments/1"))   // 해당 링크 가져옴
+            .andExpect(status().isOk())  // status가  OK인지 검사
+            .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        //  내용 검사는 hal+JSON이므로 MediaType.APPLICATION_JSON이 아니라 직접 입력해줌
+
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST 로 서비스하고, 해당 api 들의 존재 여부만 체크하게끔  통합테스트 작성