### PR TITLE
엔티티 equals() 버그 수정

### DIFF
--- a/src/main/java/com/fastcampus/newboardproject/domain/Article.java
+++ b/src/main/java/com/fastcampus/newboardproject/domain/Article.java
@@ -75,10 +75,8 @@ public class Article extends AuditingFields {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof Article article)) {
-            return false;
-        }
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/fastcampus/newboardproject/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/newboardproject/domain/ArticleComment.java
@@ -62,7 +62,7 @@ public class ArticleComment extends AuditingFields {
         if (!(o instanceof ArticleComment that)) {
             return false;
         }
-        return id != null && id.equals(that.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/fastcampus/newboardproject/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/newboardproject/domain/UserAccount.java
@@ -59,8 +59,9 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);    }
+        if (!(o instanceof UserAccount that)) return false;
+        return userId != null && userId.equals(that.getUserId());
+    }
 
     @Override
     public int hashCode() {


### PR DESCRIPTION
테스트 도중 밝혀진 엔티티 `equals()` 구현 코드의 문제를 해결하는 pr

This closes #49 